### PR TITLE
Run without installation with clean up option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This prints out what you need to run to get a similar container. You can do `$(r
 ## Run without installing
 
 ```
-docker run -v /var/run/docker.sock:/var/run/docker.sock \
+docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
     assaflavie/runlike YOUR-CONTAINER
 ```
 


### PR DESCRIPTION
So it is better to run docker with clean up option (--rm)

```
Clean up (--rm)
automatically clean up the container and remove the file system when the container exits
```