### PR TITLE
Quote values for multi_options with pipes.quote

### DIFF
--- a/fixtures.sh
+++ b/fixtures.sh
@@ -18,6 +18,7 @@ docker run -d --name runlike_fixture1 \
     --label com.example.group="one" \
     --label com.example.environment="test" \
     --restart=always \
+    --env "FOO=thing=\"quoted value with 'spaces' and 'single quotes'\"" \
     -v $(pwd):/workdir \
     -v /random_volume \
     runlike_fixture

--- a/runlike/inspector.py
+++ b/runlike/inspector.py
@@ -1,5 +1,6 @@
 from subprocess import check_output, STDOUT, CalledProcessError
 from json import loads
+import pipes
 import sys
 import re
 
@@ -42,7 +43,7 @@ class Inspector(object):
         values = self.get_fact(path)
         if values:
             for val in values:
-                self.options.append('--%s="%s"' % (option, val))
+                self.options.append('--%s=%s' % (option, pipes.quote(val)))
 
 
     def parse_hostname(self):

--- a/test_runlike.py
+++ b/test_runlike.py
@@ -1,5 +1,6 @@
 import unittest
 import os
+import pipes
 from subprocess import check_output
 from runlike.inspector import Inspector
 
@@ -46,10 +47,10 @@ class TestInspection(unittest.TestCase):
 
     def test_host_volumes(self):
         cur_dir = os.path.dirname(os.path.realpath(__file__))
-        self.expect_substr("--volume=\"%s:/workdir\"" % cur_dir)
+        self.expect_substr("--volume=%s:/workdir" % pipes.quote(cur_dir))
 
     def test_no_host_volume(self):
-        self.expect_substr('--volume="/random_volume"')
+        self.expect_substr('--volume=/random_volume')
 
     def test_restart_always(self):
         self.expect_substr('--restart=always \\')
@@ -104,3 +105,7 @@ class TestInspection(unittest.TestCase):
     def test_mac_address(self):
         self.expect_substr('--mac-address=6a:00:01:ad:d9:e0', 4)
         self.dont_expect_substr('--mac-address', 2)
+
+    def test_env(self):
+        val = '''FOO=thing="quoted value with 'spaces' and 'single quotes'"'''
+        self.expect_substr("""--env=%s""" % pipes.quote(val))


### PR DESCRIPTION
This will handle (e.g.) environment variables with various quoting in it more correctly.

