### PR TITLE
Fix label and cmd args quoting (#38)

### DIFF
--- a/fixtures.sh
+++ b/fixtures.sh
@@ -19,8 +19,8 @@ docker run -d --name runlike_fixture1 \
     --dns=8.8.8.8 --dns=8.8.4.4 \
     --user daemon \
     --device=/dev/null:/dev/null:r \
-    --label com.example.group="one" \
-    --label com.example.environment="test" \
+    --label='com.example.notescaped=$2y$17$P06LST8KwocXXXXXXX' \
+    --label='com.example.environment=test' \
     --add-host hostname2:127.0.0.2 \
     --add-host hostname3:127.0.0.3 \
     --log-driver=fluentd \
@@ -38,7 +38,7 @@ docker run -d --name runlike_fixture2 \
     --restart=on-failure \
     --net host \
     --device=/dev/null:/dev/null \
-    --label com.example.version="1" \
+    --label='com.example.version=1' \
     runlike_fixture \
     /bin/bash sleep.sh
 

--- a/test_runlike.py
+++ b/test_runlike.py
@@ -90,11 +90,12 @@ class TestInspection(unittest.TestCase):
         self.dont_expect_substr('--privileged \\', 2)
 
     def test_multi_labels(self):
-        self.expect_substr('--label com.example.environment="test" \\', 1)
-        self.expect_substr('--label com.example.group="one" \\', 1)
+        self.expect_substr("--label='com.example.environment=test' \\", 1)
+        self.expect_substr(
+            "--label='com.example.notescaped=$2y$17$P06LST8KwocXXXXXXX' \\", 1)
 
     def test_one_label(self):
-        self.expect_substr('--label com.example.version="1" \\', 2)
+        self.expect_substr("--label='com.example.version=1' \\", 2)
 
     def test_labels_not_present(self):
         self.dont_expect_substr('--label', 3)


### PR DESCRIPTION
__Change example__
Initial command:
```bash
docker run \
  --rm \
  --name=test \
  --env=AAA=1 \
  --env='PASSWORD=$2y$17$P06LST8KwocXXXXXXX' \
  --label='traefik.frontend.rule=Host:my.host.com:$HOME' \
  portainer/portainer \
    --admin-password '$2y$17$P06LST8KwocXXXXXXX'
```
Current output:
```bash
docker run \
        --name=test \
        --hostname=62b294c0f917 \
        --env=AAA=1 \
        --env='PASSWORD=$2y$17$P06LST8KwocXXXXXXX' \
        --env=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
        --volume=/data \
        --expose=9000 \
        --restart=no \
        --label traefik.frontend.rule="Host:my.host.com:$HOME" \
        # <-- On copy-paste $HOME variable will be resolved! \
        portainer/portainer \
        --admin-password $2y$17$P06LST8KwocXXXXXXX \
        # <-- On copy-paste $2, $1 and $P06LST8KwocXXXXXXX variables will be \
        # resolved, resulting in new password being 'y7'!
```
Fixed output:
```bash
docker run \
        --name=test \
        --hostname=62b294c0f917 \
        --env=AAA=1 \
        --env='PASSWORD=$2y$17$P06LST8KwocXXXXXXX' \
        --env=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
        --volume=/data \
        --expose=9000 \
        --restart=no \
        --label='traefik.frontend.rule=Host:my.host.com:$HOME' \
        portainer/portainer \
        --admin-password '$2y$17$P06LST8KwocXXXXXXX'
```