### PR TITLE
Fix: crush on json loads

### DIFF
--- a/runlike/inspector.py
+++ b/runlike/inspector.py
@@ -27,7 +27,7 @@ class Inspector(object):
             output = check_output(
                 ["docker", "inspect", self.container],
                 stderr=STDOUT)
-            self.facts = loads(output)
+            self.facts = loads(output.decode())
         except CalledProcessError as e:
             if "No such image or container" in e.output:
                 die("No such container %s" % self.container)


### PR DESCRIPTION
Encountered on: Ubuntu 16.04.6 LTS (Python 3.5.2)
Error:

```bash
Traceback (most recent call last):                                                                                                             
  File "/usr/local/bin/runlike", line 8, in <module>                                                                                           
    sys.exit(main())                                                                                                                           
  File "/usr/local/lib/python3.5/dist-packages/runlike/runlike.py", line 28, in main                                                           
    cli()                                                                                                                                      
  File "/usr/local/lib/python3.5/dist-packages/click/core.py", line 764, in __call__                                                           
    return self.main(*args, **kwargs)                                                                                                          
  File "/usr/local/lib/python3.5/dist-packages/click/core.py", line 717, in main                                                               
    rv = self.invoke(ctx)                                                                                                                      
  File "/usr/local/lib/python3.5/dist-packages/click/core.py", line 956, in invoke                                                             
    return ctx.invoke(self.callback, **ctx.params)                                                                                             
  File "/usr/local/lib/python3.5/dist-packages/click/core.py", line 555, in invoke                                                             
    return callback(*args, **kwargs)                                                                                                           
  File "/usr/local/lib/python3.5/dist-packages/runlike/runlike.py", line 23, in cli                                                            
    ins.inspect()                                                                                                                              
  File "/usr/local/lib/python3.5/dist-packages/runlike/inspector.py", line 26, in inspect                                                      
    self.facts = loads(output)                                                                                                                 
  File "/usr/lib/python3.5/json/__init__.py", line 312, in loads                                                                               
    s.__class__.__name__))                                                                                                                     
TypeError: the JSON object must be str, not 'bytes'
```
