### PR TITLE
Switch to alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
-FROM docker
+FROM python:3.11-alpine
 
-RUN apk add --no-cache python3 curl
-RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-RUN python3 get-pip.py
 RUN pip install runlike
 
 ENTRYPOINT ["runlike"]


### PR DESCRIPTION
Python already offers Docker images. I switched to alpine because runlike takes up more than 300 MB in uncompressed image size, while alpine is about 30 MB.