### PR TITLE
feat: directory mounting supports bind and volume modes

### DIFF
--- a/runlike/inspector.py
+++ b/runlike/inspector.py
@@ -117,6 +117,19 @@ class Inspector(object):
 
                 self.options.append(f"{option_part}{hostname_part}{host_port_part}{container_port}{protocol_part}")
 
+    def parse_volumes(self):
+        mounts = self.get_container_fact("Mounts")
+        for mount in mounts:
+            if mount["Type"] == "volume":
+                volume_format = f'{mount["Name"]}:{mount["Destination"]}'
+            else:
+                volume_format = f'{mount["Source"]}:{mount["Destination"]}'
+            if mount.get("RW"):
+                volume_format += ':rw'
+            else:
+                volume_format += ':ro'
+            self.options.append(f"--volume {volume_format}")
+
     def parse_links(self):
         links = self.get_container_fact("HostConfig.Links")
         link_options = set()
@@ -233,9 +246,9 @@ class Inspector(object):
         self.parse_pid()
         self.parse_cpuset()
 
+        self.parse_volumes()
+
         self.multi_option("Config.Env", "env")
-        self.multi_option("HostConfig.Binds", "volume")
-        self.multi_option("Config.Volumes", "volume")
         self.multi_option("HostConfig.VolumesFrom", "volumes-from")
         self.multi_option("HostConfig.CapAdd", "cap-add")
         self.multi_option("HostConfig.CapDrop", "cap-drop")

--- a/test_runlike.py
+++ b/test_runlike.py
@@ -82,7 +82,9 @@ class TestRunlike(BaseTest):
         self.expect_substr('--restart=on-failure:3 \\', 3)
 
     def test_restart_not_present(self):
-        self.dont_expect_substr('--restart', 4)
+        # If the restart policy is not set, the default value is no.
+        # self.dont_expect_substr('--restart', 4)
+        self.expect_substr('--restart=no \\')
 
     def test_hostname(self):
         self.expect_substr('--hostname=Essos \\')
@@ -91,7 +93,9 @@ class TestRunlike(BaseTest):
         self.dont_expect_substr('--hostname \\', 2)
 
     def test_network_mode(self):
-        self.dont_expect_substr('--network', 1)
+        # When no network mode is set, bridge is used by default
+        # self.dont_expect_substr('--network', 1)
+        self.expect_substr('--network=bridge', 1)
         self.expect_substr('--network=host', 2)
         self.expect_substr('--network=runlike_fixture_bridge', 3)
 

--- a/test_runlike.py
+++ b/test_runlike.py
@@ -83,7 +83,6 @@ class TestRunlike(BaseTest):
 
     def test_restart_not_present(self):
         # If the restart policy is not set, the default value is no.
-        # self.dont_expect_substr('--restart', 4)
         self.expect_substr('--restart=no \\', 4)
 
     def test_hostname(self):
@@ -94,7 +93,6 @@ class TestRunlike(BaseTest):
 
     def test_network_mode(self):
         # When no network mode is set, bridge is used by default
-        # self.dont_expect_substr('--network', 1)
         self.expect_substr('--network=bridge', 1)
         self.expect_substr('--network=host', 2)
         self.expect_substr('--network=runlike_fixture_bridge', 3)

--- a/test_runlike.py
+++ b/test_runlike.py
@@ -60,10 +60,10 @@ class TestRunlike(BaseTest):
 
     def test_host_volumes(self):
         cur_dir = os.path.dirname(os.path.realpath(__file__))
-        self.expect_substr("--volume=%s:/workdir" % pipes.quote(cur_dir))
+        self.expect_substr("--volume %s:/workdir:rw" % pipes.quote(cur_dir))
 
     def test_no_host_volume(self):
-        self.expect_substr('--volume=/random_volume')
+        self.expect_substr('--volume=/random_volume:rw')
 
     def test_tty(self):
         self.expect_substr('-t \\')

--- a/test_runlike.py
+++ b/test_runlike.py
@@ -63,7 +63,7 @@ class TestRunlike(BaseTest):
         self.expect_substr("--volume %s:/workdir:rw" % pipes.quote(cur_dir))
 
     def test_no_host_volume(self):
-        self.expect_substr('--volume=/random_volume:rw')
+        self.expect_substr(':/random_volume:rw')
 
     def test_tty(self):
         self.expect_substr('-t \\')

--- a/test_runlike.py
+++ b/test_runlike.py
@@ -84,7 +84,7 @@ class TestRunlike(BaseTest):
     def test_restart_not_present(self):
         # If the restart policy is not set, the default value is no.
         # self.dont_expect_substr('--restart', 4)
-        self.expect_substr('--restart=no \\')
+        self.expect_substr('--restart=no \\', 4)
 
     def test_hostname(self):
         self.expect_substr('--hostname=Essos \\')


### PR DESCRIPTION
In the old code, using  `Config.Volumes` and `HostConfig.Binds` to get volume can only display volume mounts in bind mode normally.
I changed it to get the volume through the `Mounts` data string, so that both `bind` and `volume` mounting can be obtained normally.
```json
[
    {
        "Id": "81da5acdde68bc319ebdcf306112ee7b2ba3ad9fd5105a2aeea1bd3d00c042ba",
        "Mounts": [
            {
                "Type": "bind",
                "Source": "/xxxx/data",
                "Destination": "/xxxx/data",
                "Mode": "rw",
                "RW": true,
                "Propagation": "rprivate"
            },
            {
                "Type": "volume",
                "Name": "31528af375053362a6b7f74650cfc8c39b22808af111581190d8efd30c47aee5",
                "Source": "/xxx/volumes/31528af375053362a6b7f74650cfc8c39b22808af111581190d8efd30c47aee5/_data",
                "Destination": "/xxxx/data",
                "Driver": "local",
                "Mode": "rw",
                "RW": true,
                "Propagation": ""
            }
        ]
    }
]

```