### PR TITLE
fix: support python3.13

### DIFF
--- a/runlike/inspector.py
+++ b/runlike/inspector.py
@@ -5,7 +5,7 @@ from subprocess import (
     CalledProcessError
 )
 from json import loads
-from pipes import quote
+from shlex import quote
 
 
 def die(message):


### PR DESCRIPTION
for  python3.13 the  pipes module was removed completely in Python 3.13.
more to check https://github.com/llvm/llvm-project/pull/93376