### PR TITLE
Add flag for disabling labels from the output

### DIFF
--- a/runlike/inspector.py
+++ b/runlike/inspector.py
@@ -11,9 +11,10 @@ def die(message):
 
 class Inspector(object):
 
-    def __init__(self, container=None, no_name=None, use_volume_id=None, pretty=None):
+    def __init__(self, container=None, no_name=None, use_volume_id=None, pretty=None, no_labels=None):
         self.container = container
         self.no_name = no_name
+        self.no_labels = no_labels
         self.use_volume_id = use_volume_id
         self.pretty = pretty
         self.container_facts = None
@@ -287,7 +288,8 @@ class Inspector(object):
         self.parse_links()
         self.parse_restart()
         self.parse_devices()
-        self.parse_labels()
+        if not self.no_labels:
+            self.parse_labels()
         self.parse_log()
         self.parse_extra_hosts()
         self.parse_runtime()

--- a/runlike/runlike.py
+++ b/runlike/runlike.py
@@ -22,11 +22,13 @@ except (ValueError, ImportError):
     help="Keep the automatically assigned volume id")
 @click.option("-p", "--pretty", is_flag=True)
 @click.option("-s", "--stdin", is_flag=True)
-def cli(container, no_name, use_volume_id, pretty, stdin):
+@click.option("-l", "--no-labels", is_flag=True)
+
+def cli(container, no_name, use_volume_id, pretty, stdin, no_labels):
 
     # TODO: -i, -t, -d as added options that override the inspection
     if container or stdin:
-        ins = Inspector(container, no_name, use_volume_id, pretty)
+        ins = Inspector(container, no_name, use_volume_id, pretty, no_labels)
         if container:
             ins.inspect()
         elif stdin:

--- a/runlike/runlike.py
+++ b/runlike/runlike.py
@@ -22,7 +22,7 @@ except (ValueError, ImportError):
     help="Keep the automatically assigned volume id")
 @click.option("-p", "--pretty", is_flag=True)
 @click.option("-s", "--stdin", is_flag=True)
-@click.option("-l", "--no-labels", is_flag=True)
+@click.option("-l", "--no-labels", is_flag=True, help="Do not include labels in output")
 
 def cli(container, no_name, use_volume_id, pretty, stdin, no_labels):
 

--- a/test_runlike.py
+++ b/test_runlike.py
@@ -217,3 +217,11 @@ class TestRunlikeNoName(BaseTest):
 
     def test_no_name(self):
         self.dont_expect_substr("--name")
+
+class TestRunlikeNoLabels(BaseTest):
+    @classmethod
+    def setUpClass(cls):
+        cls.start_runlike(["--no-labels"])
+
+    def test_no_labels(self):
+        self.dont_expect_substr("--label")


### PR DESCRIPTION
I use `runlike` a lot for debugging and I sometimes want to get the output without `labels`, as requested in https://github.com/lavie/runlike/issues/112. 

This PR simply adds a flag, `--no-labels` (though I'm not sure if `-l` is the most intuitive shorthand flag…) which excludes labels from the command output.