### PR TITLE
Add support for shm-size

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,12 +10,12 @@ jobs:
           architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
       - run: pip install poetry
       - run: poetry install
+      - run: make test
       - name: Log into Dockerhub
         if: github.event_name == 'push'
         uses: docker/login-action@v3
         with:
           username: assaflavie
           password: ${{ secrets.DOCKERHUB_TOKEN }}        
-      - run: make test
       - if: ${{ failure() }}
         run: ./inspect_fixtures.sh

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Probably **shouldn't use this in production** yet. If you do, double check that 
       --rm                             Automatically remove the container
                                        when it exits
       --runtime string                 Runtime to use for this container
+      --shm-size bytes                 Size of /dev/shm
   -t, --tty                            Allocate a pseudo-TTY
   -u, --user string                    Username or UID (format:
                                        <name|uid>[:<group|gid>])
@@ -214,7 +215,6 @@ Probably **shouldn't use this in production** yet. If you do, double check that 
                                        filesystem as read only
 
       --security-opt list              Security Options
-      --shm-size bytes                 Size of /dev/shm
       --sig-proxy                      Proxy received signals to the
                                        process (default true)
       --stop-signal string             Signal to stop a container

--- a/fixtures.sh
+++ b/fixtures.sh
@@ -47,6 +47,7 @@ sudocker run -d --name runlike_fixture1 \
     --env SET_WITHOUT_VALUE \
     --env UTF_8=ユーザー別サイト \
     --memory="2147483648" \
+    --shm-size="536870912" \
     --memory-reservation="1610612736" \
     -v $(pwd):/workdir \
     -v $(pwd):/workdir_ro:ro \

--- a/runlike/inspector.py
+++ b/runlike/inspector.py
@@ -246,6 +246,11 @@ class Inspector(object):
         if runtime:
             self.options.append(f"--runtime={runtime}")
 
+    def parse_shm_size(self):
+        shm_size = self.get_container_fact("HostConfig.ShmSize")
+        if shm_size:
+            self.options.append(f'--shm-size="{shm_size}"')
+
     def parse_memory(self):
         memory = self.get_container_fact("HostConfig.Memory")
         if memory:
@@ -301,6 +306,7 @@ class Inspector(object):
         self.parse_log()
         self.parse_extra_hosts()
         self.parse_runtime()
+        self.parse_shm_size()
         self.parse_memory()
         self.parse_memory_reservation()
 

--- a/test_runlike.py
+++ b/test_runlike.py
@@ -189,6 +189,9 @@ class TestRunlike(BaseTest):
     def test_runtime(self):
         self.expect_substr("--runtime=runc")
 
+    def test_shm_size(self):
+        self.expect_substr("--shm-size=536870912")
+
     def test_pid_mode(self):
         self.expect_substr("--pid host", 2)
         self.dont_expect_substr("--pid")

--- a/test_runlike.py
+++ b/test_runlike.py
@@ -190,7 +190,7 @@ class TestRunlike(BaseTest):
         self.expect_substr("--runtime=runc")
 
     def test_shm_size(self):
-        self.expect_substr("--shm-size=536870912")
+        self.expect_substr('--shm-size="536870912"')
 
     def test_pid_mode(self):
         self.expect_substr("--pid host", 2)


### PR DESCRIPTION
Hi,

This passes `HostConfig.ShmSize` through as `--shm-size`.

I also moved the tests earlier in the CI pipeline so I could see the result before it bombs out on the Docker Hub credentials, which I obviously don't have.

Thanks!