### PR TITLE
Escape spaces in directory names

### DIFF
--- a/runlike/inspector.py
+++ b/runlike/inspector.py
@@ -139,11 +139,9 @@ class Inspector(object):
     def parse_volumes(self):
         mounts = self.get_container_fact("Mounts")
         for mount in mounts:
-
             name = mount.get("Name", "").replace(' ', '\\ ')
             destination = mount.get("Destination", "").replace(' ', '\\ ')
             source = mount.get("Source", "").replace(' ', '\\ ')
-
             if mount["Type"] == "volume":
                 if self.use_volume_id:
                     volume_format = f'{name}:{destination}'

--- a/runlike/inspector.py
+++ b/runlike/inspector.py
@@ -139,13 +139,18 @@ class Inspector(object):
     def parse_volumes(self):
         mounts = self.get_container_fact("Mounts")
         for mount in mounts:
+
+            name = mount.get("Name", "").replace(' ', '\\ ')
+            destination = mount.get("Destination", "").replace(' ', '\\ ')
+            source = mount.get("Source", "").replace(' ', '\\ ')
+
             if mount["Type"] == "volume":
                 if self.use_volume_id:
-                    volume_format = f'{mount["Name"]}:{mount["Destination"]}'
+                    volume_format = f'{name}:{destination}'
                 else:
-                    volume_format = f'{mount["Destination"]}'
+                    volume_format = f'{destination}'
             else:
-                volume_format = f'{mount["Source"]}:{mount["Destination"]}'
+                volume_format = f'{source}:{destination}'
             if not mount.get("RW"):
                 volume_format += ':ro'
             self.options.append(f"--volume {volume_format}")

--- a/test_runlike.py
+++ b/test_runlike.py
@@ -240,3 +240,6 @@ class TestRunlikeUseVolumeId(BaseTest):
 
     def test_no_host_volume(self):
         self.expect_substr("--volume test_volume:/test_volume")
+
+    def test_space_in_volume(self):
+        self.expect_substr("--volume test volume:/test volume")


### PR DESCRIPTION
If you have a space in a directory name you have to escape it or wrap it in quotes when running docker run with the output of runlike. This pull request escapes spaces in directory names.

Not sure if I updated test_runlike.py correctly or if you are even interrested in adding this change to runlike. Feel free to unceremoniously close this PR if not interrested, Thanks!