### PR TITLE
feat(--cpus): add support for --cpus flag

### DIFF
--- a/runlike/inspector.py
+++ b/runlike/inspector.py
@@ -267,6 +267,11 @@ class Inspector(object):
         if len(entrypoints) > 0 and entrypoints != image_entrypoints:
             self.options.append("--entrypoint %s" % entrypoints[0])
 
+    def parse_nanocpus(self): 
+        cpus = self.get_container_fact("HostConfig.NanoCpus")
+        if cpus:
+            self.options.append(f'--cpus="{cpus/1000000000}"')
+
     def format_cli(self):
         image = self.get_container_fact("Config.Image")
         self.options = []
@@ -309,6 +314,7 @@ class Inspector(object):
         self.parse_shm_size()
         self.parse_memory()
         self.parse_memory_reservation()
+        self.parse_nanocpus()
 
         stdout_attached = self.get_container_fact("Config.AttachStdout")
         if not stdout_attached:


### PR DESCRIPTION
This commit adds support for the --cpus flag, allowing users to reproduce container CPU limits. The `docker inspect` command outputs this value as `NanoCpus`, an integer. However, the `docker run` command expects a floating-point number for the `--cpus` flag.

This implementation correctly parses the `NanoCpus` integer and converts it to a floating-point number. For example, a value of 1,000,000,000 NanoCpus will be correctly represented as 1.0 in the generated `docker run` command.