### PR TITLE
fix: properly quote volume paths with spaces in docker run output

### DIFF
--- a/runlike/inspector.py
+++ b/runlike/inspector.py
@@ -141,11 +141,11 @@ class Inspector(object):
         for mount in mounts:
             if mount["Type"] == "volume":
                 if self.use_volume_id:
-                    volume_format = f'{mount["Name"]}:{mount["Destination"]}'
+                    volume_format = f'{quote(mount["Name"])}:{quote(mount["Destination"])}'
                 else:
-                    volume_format = f'{mount["Destination"]}'
+                    volume_format = f'{quote(mount["Destination"])}'
             else:
-                volume_format = f'{mount["Source"]}:{mount["Destination"]}'
+                volume_format = f'{quote(mount["Source"])}:{quote(mount["Destination"])}'
             if not mount.get("RW"):
                 volume_format += ':ro'
             self.options.append(f"--volume {volume_format}")

--- a/test_runlike.py
+++ b/test_runlike.py
@@ -240,3 +240,50 @@ class TestRunlikeUseVolumeId(BaseTest):
 
     def test_no_host_volume(self):
         self.expect_substr("--volume test_volume:/test_volume")
+
+
+class TestVolumeQuoting(unittest.TestCase):
+    """Unit tests for volume path quoting (fixes issue #134)."""
+
+    def test_quote_path_with_spaces(self):
+        """Verify that paths with spaces are properly quoted."""
+        from shlex import quote
+        path_with_space = "/path/with spaces/folder"
+        quoted = quote(path_with_space)
+        # Quoted path should not break when used in shell command
+        self.assertIn("'", quoted)
+        self.assertEqual(quoted, "'/path/with spaces/folder'")
+
+    def test_quote_normal_path(self):
+        """Verify that normal paths without spaces are not unnecessarily quoted."""
+        from shlex import quote
+        normal_path = "/normal/path/folder"
+        quoted = quote(normal_path)
+        # Normal path should not be quoted
+        self.assertEqual(quoted, normal_path)
+
+    def test_parse_volumes_with_spaces(self):
+        """Test that the Inspector correctly quotes volume paths with spaces."""
+        from runlike.inspector import Inspector
+
+        # Create a mock inspector with the necessary data
+        ins = Inspector()
+        ins.container_facts = [{
+            "Mounts": [
+                {
+                    "Type": "bind",
+                    "Source": "/path/with spaces/source",
+                    "Destination": "/dest",
+                    "RW": True
+                }
+            ]
+        }]
+        ins.image_facts = None
+
+        # Parse volumes
+        ins.parse_volumes()
+
+        # Check that the output is properly quoted
+        volume_option = ins.options[0]
+        self.assertIn("'", volume_option)
+        self.assertEqual(volume_option, "--volume '/path/with spaces/source':/dest")


### PR DESCRIPTION
## Summary

Fixes issue #134 - containers with volumes containing spaces would generate broken docker run commands.

## Root Cause

The `parse_volumes()` function in `inspector.py` was not quoting volume paths, causing commands to break when paths contain spaces.

Example from issue #134:
```
--volume /volume1/homes/JEREMYMEYERS/Drive/Backup/Music Drive/P/Sound Files:/music
```

The space in "Music Drive" would break the generated command.

## Fix

Modified `parse_volumes()` to use `shlex.quote()` (already imported) for all volume paths:

```python
# Before
volume_format = f'{mount["Source"]}:{mount["Destination"]}'

# After  
volume_format = f'{quote(mount["Source"])}:{quote(mount["Destination"])}'
```

This ensures:
- Paths with spaces are properly quoted: `'/path/with spaces':/dest`
- Normal paths without special characters remain unquoted: `/normal/path:/dest`

## Testing

Added unit tests in `test_runlike.py`:
- `test_quote_path_with_spaces`: verifies quoting behavior
- `test_quote_normal_path`: verifies no unnecessary quoting
- `test_parse_volumes_with_spaces`: verifies Inspector correctly handles paths with spaces

All tests pass.

## Example

```bash
# Before fix
--volume /volume1/homes/Backup/Music Drive/P/Sound Files:/music

# After fix  
--volume '/volume1/homes/Backup/Music Drive/P/Sound Files':/music
```

Fixes #134